### PR TITLE
- Whitelist /sbin/openrc-run

### DIFF
--- a/Mk/Scripts/qa.sh
+++ b/Mk/Scripts/qa.sh
@@ -66,7 +66,8 @@ shebangonefile() {
 	/bin/sh) ;;
 	/bin/tcsh) ;;
 	/usr/bin/awk) ;;
-	/usr/bin/env)
+	/usr/bin/env) ;;
+	/sbin/openrc-run)
 		interparg=$(sed -n -e '1s/^#![[:space:]]*[^[:space:]]*[[:space:]]*\([^[:space:]]*\).*/\1/p;2q' "${f}")
 		case "${interparg}" in
 		python|python2|python3)


### PR DESCRIPTION
Fixing Q/A tests 
====> Running Q/A tests (stage-qa)
Error: '/sbin/openrc-run' is an invalid shebang you need USES=shebangfix for 'etc/init.d/nginx'
*** Error code 1